### PR TITLE
[FEATURE] Reverse Proxy TTL handling

### DIFF
--- a/app/WebsiteCache.php
+++ b/app/WebsiteCache.php
@@ -2,25 +2,9 @@
 
 require_once __DIR__ . '/WebsiteKernel.php';
 
-use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
+use Sulu\Component\HttpCache\HttpCache;
 
 class WebsiteCache extends HttpCache
 {
-    protected function invalidate(Request $request, $catch = false)
-    {
-        if ('PURGE' !== $request->getMethod()) {
-            return parent::invalidate($request, $catch);
-        }
 
-        $response = new Response();
-        if ($this->getStore()->purge($request->getUri())) {
-            $response->setStatusCode(200, 'Purged');
-        } else {
-            $response->setStatusCode(200, 'Not purged'); // 404 ???
-        }
-
-        return $response;
-    }
 }


### PR DESCRIPTION
Currently the template cache life time is used as HTTP cache control (`Cache-Control:max-age=3600, public`) which is interpreted by browsers and reverse-proxies. To get more control over the reverse-proxy cache we introduced a new HTTP Header `X-Reverse-Proxy-TTL`. Separate options for HTTP cache control should be added (https://github.com/sulu-cmf/sulu-standard/issues/272)

This implementation enables the Symfony HttpCache to also validate the `X-Reverse-Proxy-TTL` setting.

Inspiration: https://github.com/liip/LiipCacheControlBundle#custom-varnish-time-outs

**Related PR's:**

https://github.com/sulu-cmf/sulu/pull/262
https://github.com/sulu-cmf/SuluWebsiteBundle/pull/59

**Tasks:**
- [ ] gather feedback for my changes

**Informations:**

| Q | A |
| --- | --- |
| Tests pass? | no tests |
| Fixed tickets | none |
| BC Breaks | none |
| Doc |  |
