### PR TITLE
fixed name of type map config parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu CMF
 ======================
 
 * dev-develop
+    * BUGFIX      #567  [SULU-STANDARD]   Fixed type map configuration parameter
     * ENHANCEMENT #566  [SULU-STANDARD]   Updated example template
     * BUGFIX      #561  [SULU-STANDARD]   Fixed special character search 
     * FEATURE     #562  [SULU-STANDARD]   Added prefixes to search indexes

--- a/app/config/sulu.yml
+++ b/app/config/sulu.yml
@@ -91,7 +91,7 @@ sulu_core:
                 sulu:
                     path: "%kernel.root_dir%/../vendor/sulu/sulu/src/Sulu/Bundle/CoreBundle/Content/templates"
                     type: "page"
-            typeMap:
+            type_map:
                 page: "\\Sulu\\Component\\Content\\Compat\\Structure\\PageBridge"
                 home: "\\Sulu\\Component\\Content\\Compat\\Structure\\PageBridge"
                 snippet: "\\Sulu\\Component\\Content\\Compat\\Structure\\SnippetBridge"


### PR DESCRIPTION
__tasks:__

- [ ] test coverage

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| Related PRs      | https://github.com/sulu-io/sulu/pull/1846
| BC breaks        | `sulu_core.content.structure.typeMap` is now `sulu_core.content.structure.type_map`
| Documentation PR | none