### PR TITLE
Ensure document manager debug is set to %kernel.debug%

### DIFF
--- a/app/config/sulu.yml
+++ b/app/config/sulu.yml
@@ -126,6 +126,7 @@ sulu_collaboration:
     connection_cache: doctrine_cache.providers.sulu_collaboration_connection
 
 sulu_document_manager:
+    debug: %kernel.debug%
     mapping:
         page:
             class: Sulu\Bundle\ContentBundle\Document\PageDocument


### PR DESCRIPTION
This is a simple configuration change to *ensure* that the document manager `debug` feature is `disabled` in `prod` mode.

This should be the default behavior of the document manager, however there is a bug which will be shortly fixed.

It is however better imo to have this option in the `sulu.yml` config to expose it and make the user aware of it.