### PR TITLE
enabled assetic integration of LiipThemeBundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu CMF
 ======================
 
 * dev-develop
+    * BUGFIX      #618  [SULU-STANDARD]   Use the assetic integration of the LiipThemeBundle
     * ENHANCEMENT #598  [SULU-STANDARD]   Added TranslateBundle for its commands
     * FEATURE     #592  [SULU-STANDARD]   Added translation and configuration for collaboration feature
 

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -78,4 +78,4 @@ liip_theme:
     themes: ["default"]
     active_theme: "default"
     load_controllers: false
-
+    assetic_integration: true


### PR DESCRIPTION
actually use the fix @dantleech made in https://github.com/liip/LiipThemeBundle/pull/118

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| Related PRs      | none
| BC breaks        | none
| Documentation PR | none