### PR TITLE
Updated sulu/sulu dependency since currently the SuluHashBundle is missing

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2506,7 +2506,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massiveart/MassiveSearchBundle/zipball/7a74d126629c1dbff4e6fc9e0ef663925db7b49f",
+                "url": "https://api.github.com/repos/massiveart/MassiveSearchBundle/zipball/855ce8380094c7670150f17b83888a56a173b879",
                 "reference": "7a74d126629c1dbff4e6fc9e0ef663925db7b49f",
                 "shasum": ""
             },
@@ -2795,6 +2795,60 @@
                 "service proxies"
             ],
             "time": "2015-08-09 04:28:19"
+        },
+        {
+            "name": "oro/doctrine-extensions",
+            "version": "1.0.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/orocrm/doctrine-extensions.git",
+                "reference": "068102e896c8739355b99b794d59d321dff655d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/orocrm/doctrine-extensions/zipball/068102e896c8739355b99b794d59d321dff655d7",
+                "reference": "068102e896c8739355b99b794d59d321dff655d7",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/orm": ">=2.2.3",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "doctrine/data-fixtures": "dev-master",
+                "doctrine/orm": "<2.5.0",
+                "phpunit/phpunit": "4.*",
+                "symfony/yaml": "2.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Oro\\DBAL": "src/",
+                    "Oro\\ORM": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oro, Inc",
+                    "homepage": "http://www.orocrm.com"
+                }
+            ],
+            "description": "Doctrine Extensions for MySQL and PostgreSQL.",
+            "homepage": "https://github.com/orocrm/doctrine-extensions/",
+            "keywords": [
+                "database",
+                "doctrine",
+                "dql",
+                "function",
+                "mysql",
+                "postgresql",
+                "type"
+            ],
+            "time": "2016-01-05 20:17:20"
         },
         {
             "name": "pagerfanta/pagerfanta",
@@ -3736,12 +3790,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sulu-io/sulu.git",
-                "reference": "775ebea9b99113a240246eb15fa7f89885e7eb64"
+                "reference": "ae5d812100d00ea9c73f4cab94500c742d8c386d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sulu-io/sulu/zipball/775ebea9b99113a240246eb15fa7f89885e7eb64",
-                "reference": "775ebea9b99113a240246eb15fa7f89885e7eb64",
+                "url": "https://api.github.com/repos/sulu-io/sulu/zipball/ae5d812100d00ea9c73f4cab94500c742d8c386d",
+                "reference": "ae5d812100d00ea9c73f4cab94500c742d8c386d",
                 "shasum": ""
             },
             "require": {
@@ -3756,6 +3810,7 @@
                 "imagine/imagine": "~0.6.1",
                 "liip/theme-bundle": "1.3.*",
                 "massive/search-bundle": "dev-develop",
+                "oro/doctrine-extensions": "^1.0",
                 "pagerfanta/pagerfanta": "~1.0",
                 "php": ">=5.5",
                 "pulse00/ffmpeg-bundle": "^0.5.2",
@@ -3833,7 +3888,7 @@
                 "core",
                 "sulu"
             ],
-            "time": "2016-02-22 13:13:18"
+            "time": "2016-02-25 11:27:59"
         },
         {
             "name": "swiftmailer/swiftmailer",


### PR DESCRIPTION
When installing the current Sulu Standard Edition, an exception is thrown when running `composer install`:

> Fatal error: Class 'Sulu\Bundle\HashBundle\SuluHashBundle' not found

This bundle was added in https://github.com/sulu-io/sulu-standard/commit/4d3239fc755e9c46c020cdd4403337d96615cf1a without updating the composer.lock file. I did this now.