### PR TITLE
Added PR and issue templates for GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,23 @@
+| Q | A
+| --- | ---
+| Bug? | no
+| Version Used | Specific tag or commit sha
+| New Feature? | no
+
+#### Expected Behavior
+
+What is the behavior you expect?
+
+#### Actual Behavior
+
+How does Sulu behave at the moment? 
+
+#### Steps to Reproduce
+
+What are the steps to reproduce this bug? Please add code examples,
+screenshots or links to GitHub repositories that reproduce the problem.
+
+#### Possible Solutions
+
+If you have already ideas how to solve the issue, add them here.
+Otherwise remove this section.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+| Q | A
+| --- | ---
+| Bug fix? | yes
+| New feature? | yes
+| BC breaks? | yes
+| Deprecations? | yes
+| Fixed tickets | fixes #issuenum
+| Related issues/PRs | #issuenum
+| License | MIT
+| Documentation PR | sulu-io/sulu-docs#prnum
+
+#### What's in this PR?
+
+Explain the contents of the PR.
+
+#### Why?
+
+Which problem does the PR fix? (remove this section if you linked an issue above)
+
+#### Example Usage
+
+~~~php
+// If you added new features, show examples of how to use them here
+// (remove this section if not a new feature)
+
+$foo = new Foo();
+
+// Now we can do
+$foo->doSomething();
+~~~
+
+#### BC Breaks/Deprecations
+
+Describe BC breaks/deprecations here. (remove this section if not needed)
+
+#### To Do
+
+- [ ] Create a documentation PR


### PR DESCRIPTION
This PR copies over the PR and issue templates from the [sulu-io/sulu](/sulu-io/sulu) repository.