### PR TITLE
Disable REST exception listener for the website

### DIFF
--- a/app/config/admin/sulu.yml
+++ b/app/config/admin/sulu.yml
@@ -20,9 +20,12 @@ doctrine_cache:
             file_system:
                 directory: %sulu.cache_dir%/collaboration/connection
 
-sulu_collaboration:
-    entity_cache: doctrine_cache.providers.sulu_collaboration_entity
-    connection_cache: doctrine_cache.providers.sulu_collaboration_connection
+# FOS REST Configuration
+fos_rest:
+    view:
+        formats:
+            json: ~
+            csv: ~
 
 # Massive Build Configuration
 massive_build:
@@ -64,8 +67,6 @@ sulu_contact:
             name: female
             translation: contact.contacts.formOfAddress.female
 
-fos_rest:
-    view:
-        formats:
-            json: ~
-            csv: ~
+sulu_collaboration:
+    entity_cache: doctrine_cache.providers.sulu_collaboration_entity
+    connection_cache: doctrine_cache.providers.sulu_collaboration_connection

--- a/app/config/website/sulu.yml
+++ b/app/config/website/sulu.yml
@@ -17,3 +17,8 @@ cmf_routing:
     dynamic:
         enabled: true
         route_provider_service_id: sulu_website.provider.content
+
+# FOS REST Configuration
+fos_rest:
+    exception:
+        enabled: false

--- a/composer.lock
+++ b/composer.lock
@@ -3867,12 +3867,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sulu-io/sulu.git",
-                "reference": "c2454a2306daf3a86002ae45c4cf10868d81ffe6"
+                "reference": "926ba052714b2e1c1277048af5a32a59f24cd06c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sulu-io/sulu/zipball/c2454a2306daf3a86002ae45c4cf10868d81ffe6",
-                "reference": "c2454a2306daf3a86002ae45c4cf10868d81ffe6",
+                "url": "https://api.github.com/repos/sulu-io/sulu/zipball/926ba052714b2e1c1277048af5a32a59f24cd06c",
+                "reference": "926ba052714b2e1c1277048af5a32a59f24cd06c",
                 "shasum": ""
             },
             "require": {
@@ -3965,7 +3965,7 @@
                 "core",
                 "sulu"
             ],
-            "time": "2016-03-23 16:00:35"
+            "time": "2016-03-23 18:47:56"
         },
         {
             "name": "swiftmailer/swiftmailer",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #640
| License | MIT

#### What's in this PR?

Disables the REST exception listener for the website.

#### Why?

Because the error pages didn't work anymore.
