### PR TITLE
Use handcraftedinthealps fork of ZendSearch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,22 +24,15 @@
         "sulu/sulu": "~1.6.22",
         "dantleech/phpcr-migrations-bundle": "~1.0",
         "sulu/theme-bundle": "~1.3.1",
-
         "twig/extensions": "~1.0",
         "symfony/assetic-bundle": "~2.8 || ~3.0",
-
         "doctrine/doctrine-fixtures-bundle": "~2.3",
-
-        "zendframework/zend-stdlib": "~2.3",
-        "zendframework/zendsearch": "@dev",
-
-        "massive/build-bundle": "0.3.*",
-
+        "handcraftedinthealps/zendsearch": "^2.0",
+        "massive/build-bundle": "^0.3 || ^0.4",
         "jackalope/jackalope-doctrine-dbal": "^1.2.5",
         "jackalope/jackalope-jackrabbit": "^1.2.0",
         "doctrine/doctrine-cache-bundle": "~1.0",
         "oro/doctrine-extensions": "^1.0",
-
         "pulse00/ffmpeg-bundle": "^0.6"
     },
     "require-dev": {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR uses the latest version of the handcraftedinthealps fork of ZendSearch.

#### Why?

Because this version supports PHP 7.4 as well.